### PR TITLE
Switch to wz/xy pairings

### DIFF
--- a/rust/results/pairs/wts/find_1/result.log
+++ b/rust/results/pairs/wts/find_1/result.log
@@ -2,25 +2,25 @@
 (-1, 1, 1, 1)
 generated 2 different rowsums
 results/pairs/wts/find_1/rowsum_1_1_1_1
-The function took: 0.10874054 seconds to generate sequences with rowsums: 1, 1, 1, 1
-The function took: 0.037901554 seconds to go through the two sets of pairs
+The function took: 0.041595917 seconds to generate sequences with rowsums: 1, 1, 1, 1
+The function took: 0.03754868 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_1/rowsum_-1_1_1_1
-The function took: 0.09323866 seconds to generate sequences with rowsums: 1, 1, 1, -1
-The function took: 0.043331034 seconds to go through the two sets of pairs
+The function took: 0.022853928 seconds to generate sequences with rowsums: 1, 1, 1, -1
+The function took: 0.028785832 seconds to go through the two sets of pairs
 
-Creating the sequences took 1 seconds. 
+Creating the sequences took 0 seconds. 
  
 
 results/pairs/wts/find_1/rowsum_-1_1_1_1/pair_WX.pair
 results/pairs/wts/find_1/rowsum_-1_1_1_1/pair_YZ.pair
 results/pairs/wts/find_1/rowsum_1_1_1_1/pair_XY.pair
 results/pairs/wts/find_1/rowsum_1_1_1_1/pair_ZW.pair
-Sorting the files took 0 seconds. 
+Sorting the files took 1 seconds. 
  
 
 ./results/pairs/wts/find_1
-Folder rowsum_1_1_1_1 : sequences have order (Z, W, X, Y)
+Folder rowsum_1_1_1_1 : sequences have order (X, Y, Z, W)
 Folder rowsum_-1_1_1_1 : sequences have order (W, X, Y, Z)
 
 count before equivalences 2

--- a/rust/results/pairs/wts/find_10/result.log
+++ b/rust/results/pairs/wts/find_10/result.log
@@ -3,18 +3,18 @@
 (-2, 2, 4, 4)
 generated 3 different rowsums
 results/pairs/wts/find_10/rowsum_0_0_2_6
-The function took: 2.0742881 seconds to generate sequences with rowsums: 6, 2, 0, 0
-The function took: 0.78381896 seconds to go through the two sets of pairs
+The function took: 0.04230523 seconds to generate sequences with rowsums: 6, 2, 0, 0
+The function took: 0.39000294 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_10/rowsum_2_2_4_4
-The function took: 0.4152866 seconds to generate sequences with rowsums: 4, 4, 2, 2
-The function took: 0.51454586 seconds to go through the two sets of pairs
+The function took: 0.030629093 seconds to generate sequences with rowsums: 4, 4, 2, 2
+The function took: 0.33369482 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_10/rowsum_-2_2_4_4
-The function took: 0.5282794 seconds to generate sequences with rowsums: 4, 4, 2, -2
-The function took: 0.9734843 seconds to go through the two sets of pairs
+The function took: 0.043089688 seconds to generate sequences with rowsums: 4, 4, 2, -2
+The function took: 0.3152745 seconds to go through the two sets of pairs
 
-Creating the sequences took 7 seconds. 
+Creating the sequences took 1 seconds. 
  
 
 results/pairs/wts/find_10/rowsum_-2_2_4_4/pair_YX.pair
@@ -23,18 +23,15 @@ results/pairs/wts/find_10/rowsum_0_0_2_6/pair_WZ.pair
 results/pairs/wts/find_10/rowsum_0_0_2_6/pair_YX.pair
 results/pairs/wts/find_10/rowsum_2_2_4_4/pair_XY.pair
 results/pairs/wts/find_10/rowsum_2_2_4_4/pair_ZW.pair
-Sorting the files took 1 seconds. 
+Sorting the files took 0 seconds. 
  
 
 ./results/pairs/wts/find_10
-Folder rowsum_0_0_2_6 : sequences have order (Y, X, W, Z)
-Folder rowsum_2_2_4_4 : sequences have order (Z, W, X, Y)
 Folder rowsum_-2_2_4_4 : sequences have order (Z, W, Y, X)
-
-count before equivalences 819
-The function found a total of 38400 sequences without any equivalences
-count after equivalences 28
-Matching the sequences took 4 seconds. 
+thread 'main' panicked at src/find/find_write.rs:470:40:
+index out of bounds: the len is 120 but the index is 128
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 12 seconds.
+Total execution time was 1 seconds.

--- a/rust/results/pairs/wts/find_11/result.log
+++ b/rust/results/pairs/wts/find_11/result.log
@@ -2,12 +2,12 @@
 (-1, 3, 3, 5)
 generated 2 different rowsums
 results/pairs/wts/find_11/rowsum_1_3_3_5
-The function took: 0.107423 seconds to generate sequences with rowsums: 5, 3, 3, 1
-The function took: 1.6702039 seconds to go through the two sets of pairs
+The function took: 0.060189392 seconds to generate sequences with rowsums: 5, 3, 3, 1
+The function took: 1.7374074 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_11/rowsum_-1_3_3_5
-The function took: 0.07083115 seconds to generate sequences with rowsums: 5, 3, 3, -1
-The function took: 1.9882636 seconds to go through the two sets of pairs
+The function took: 0.032988567 seconds to generate sequences with rowsums: 5, 3, 3, -1
+The function took: 1.4323784 seconds to go through the two sets of pairs
 
 Creating the sequences took 4 seconds. 
  
@@ -20,13 +20,11 @@ Sorting the files took 1 seconds.
  
 
 ./results/pairs/wts/find_11
-Folder rowsum_-1_3_3_5 : sequences have order (W, Y, Z, X)
 Folder rowsum_1_3_3_5 : sequences have order (Z, X, W, Y)
-
-count before equivalences 256
-The function found a total of 21120 sequences without any equivalences
-count after equivalences 4
-Matching the sequences took 4 seconds. 
+thread 'main' panicked at src/find/find_write.rs:468:40:
+index out of bounds: the len is 330 but the index is 341
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 9 seconds.
+Total execution time was 5 seconds.

--- a/rust/results/pairs/wts/find_12/result.log
+++ b/rust/results/pairs/wts/find_12/result.log
@@ -3,18 +3,18 @@
 (-2, 2, 2, 6)
 generated 3 different rowsums
 results/pairs/wts/find_12/rowsum_0_4_4_4
-The function took: 0.12943171 seconds to generate sequences with rowsums: 4, 4, 4, 0
-The function took: 6.140715 seconds to go through the two sets of pairs
+The function took: 0.27150843 seconds to generate sequences with rowsums: 4, 4, 4, 0
+The function took: 4.8484783 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_12/rowsum_2_2_2_6
-The function took: 0.070425674 seconds to generate sequences with rowsums: 6, 2, 2, 2
-The function took: 6.7262125 seconds to go through the two sets of pairs
+The function took: 0.07245231 seconds to generate sequences with rowsums: 6, 2, 2, 2
+The function took: 5.3685775 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_12/rowsum_-2_2_2_6
-The function took: 0.11722447 seconds to generate sequences with rowsums: 6, 2, 2, -2
-The function took: 6.582098 seconds to go through the two sets of pairs
+The function took: 0.102978185 seconds to generate sequences with rowsums: 6, 2, 2, -2
+The function took: 5.592089 seconds to go through the two sets of pairs
 
-Creating the sequences took 20 seconds. 
+Creating the sequences took 17 seconds. 
  
 
 results/pairs/wts/find_12/rowsum_-2_2_2_6/pair_WY.pair
@@ -23,18 +23,15 @@ results/pairs/wts/find_12/rowsum_0_4_4_4/pair_WX.pair
 results/pairs/wts/find_12/rowsum_0_4_4_4/pair_YZ.pair
 results/pairs/wts/find_12/rowsum_2_2_2_6/pair_WY.pair
 results/pairs/wts/find_12/rowsum_2_2_2_6/pair_ZX.pair
-Sorting the files took 4 seconds. 
+Sorting the files took 1 seconds. 
  
 
 ./results/pairs/wts/find_12
-Folder rowsum_2_2_2_6 : sequences have order (Z, X, W, Y)
-Folder rowsum_-2_2_2_6 : sequences have order (Z, X, W, Y)
 Folder rowsum_0_4_4_4 : sequences have order (Y, Z, W, X)
-
-count before equivalences 4728
-The function found a total of 147456 sequences without any equivalences
-count after equivalences 64
-Matching the sequences took 14 seconds. 
+thread 'main' panicked at src/find/find_write.rs:469:40:
+index out of bounds: the len is 495 but the index is 540
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 1 seconds. 
  
 
-Total execution time was 38 seconds.
+Total execution time was 19 seconds.

--- a/rust/results/pairs/wts/find_13/result.log
+++ b/rust/results/pairs/wts/find_13/result.log
@@ -6,30 +6,30 @@
 (-3, 3, 3, 5)
 generated 6 different rowsums
 results/pairs/wts/find_13/rowsum_1_1_1_7
-The function took: 0.21460451 seconds to generate sequences with rowsums: 7, 1, 1, 1
-The function took: 27.508297 seconds to go through the two sets of pairs
+The function took: 0.047365364 seconds to generate sequences with rowsums: 7, 1, 1, 1
+The function took: 22.426353 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_13/rowsum_-1_1_1_7
-The function took: 0.28106165 seconds to generate sequences with rowsums: 7, 1, 1, -1
-The function took: 27.536066 seconds to go through the two sets of pairs
+The function took: 0.07978264 seconds to generate sequences with rowsums: 7, 1, 1, -1
+The function took: 22.880465 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_13/rowsum_1_1_5_5
-The function took: 0.5246937 seconds to generate sequences with rowsums: 5, 5, 1, 1
-The function took: 28.103035 seconds to go through the two sets of pairs
+The function took: 0.10107719 seconds to generate sequences with rowsums: 5, 5, 1, 1
+The function took: 17.549952 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_13/rowsum_-1_1_5_5
-The function took: 0.10031504 seconds to generate sequences with rowsums: 5, 5, 1, -1
-The function took: 27.694796 seconds to go through the two sets of pairs
+The function took: 0.034121748 seconds to generate sequences with rowsums: 5, 5, 1, -1
+The function took: 18.079573 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_13/rowsum_3_3_3_5
-The function took: 0.45408365 seconds to generate sequences with rowsums: 5, 3, 3, 3
-The function took: 22.261301 seconds to go through the two sets of pairs
+The function took: 0.02821022 seconds to generate sequences with rowsums: 5, 3, 3, 3
+The function took: 18.457363 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_13/rowsum_-3_3_3_5
-The function took: 0.107942544 seconds to generate sequences with rowsums: 5, 3, 3, -3
-The function took: 21.912006 seconds to go through the two sets of pairs
+The function took: 0.040557332 seconds to generate sequences with rowsums: 5, 3, 3, -3
+The function took: 18.27841 seconds to go through the two sets of pairs
 
-Creating the sequences took 156 seconds. 
+Creating the sequences took 118 seconds. 
  
 
 results/pairs/wts/find_13/rowsum_-1_1_1_7/pair_WY.pair
@@ -44,21 +44,17 @@ results/pairs/wts/find_13/rowsum_1_1_5_5/pair_XY.pair
 results/pairs/wts/find_13/rowsum_1_1_5_5/pair_ZW.pair
 results/pairs/wts/find_13/rowsum_3_3_3_5/pair_WY.pair
 results/pairs/wts/find_13/rowsum_3_3_3_5/pair_ZX.pair
-Sorting the files took 9 seconds. 
+Sorting the files took 7 seconds. 
  
 
 ./results/pairs/wts/find_13
-Folder rowsum_1_1_5_5 : sequences have order (Z, W, X, Y)
-Folder rowsum_1_1_1_7 : sequences have order (W, Y, Z, X)
-Folder rowsum_-1_1_1_7 : sequences have order (Z, X, W, Y)
-Folder rowsum_-1_1_5_5 : sequences have order (Z, W, Y, X)
-Folder rowsum_-3_3_3_5 : sequences have order (W, Y, Z, X)
 Folder rowsum_3_3_3_5 : sequences have order (W, Y, Z, X)
-
-count before equivalences 2172
-The function found a total of 67392 sequences without any equivalences
-count after equivalences 12
-Matching the sequences took 14 seconds. 
+Folder rowsum_1_1_1_7 : sequences have order (Z, X, W, Y)
+Folder rowsum_1_1_5_5 : sequences have order (X, Y, Z, W)
+thread 'main' panicked at src/find/find_write.rs:470:40:
+index out of bounds: the len is 715 but the index is 1241
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 1 seconds. 
  
 
-Total execution time was 180 seconds.
+Total execution time was 126 seconds.

--- a/rust/results/pairs/wts/find_14/result.log
+++ b/rust/results/pairs/wts/find_14/result.log
@@ -2,31 +2,29 @@
 (0, 2, 6, 4)
 generated 2 different rowsums
 results/pairs/wts/find_14/rowsum_0_2_4_6
-The function took: 0.0973584 seconds to generate sequences with rowsums: 6, 4, 2, 0
-The function took: 95.06335 seconds to go through the two sets of pairs
+The function took: 0.034111988 seconds to generate sequences with rowsums: 6, 4, 2, 0
+The function took: 64.43473 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_14/rowsum_0_2_6_4
-The function took: 0.10956665 seconds to generate sequences with rowsums: 6, 4, 2, 0
-The function took: 94.702705 seconds to go through the two sets of pairs
+The function took: 0.016772397 seconds to generate sequences with rowsums: 6, 4, 2, 0
+The function took: 64.86041 seconds to go through the two sets of pairs
 
-Creating the sequences took 190 seconds. 
+Creating the sequences took 130 seconds. 
  
 
 results/pairs/wts/find_14/rowsum_0_2_4_6/pair_WZ.pair
 results/pairs/wts/find_14/rowsum_0_2_4_6/pair_YX.pair
 results/pairs/wts/find_14/rowsum_0_2_6_4/pair_YX.pair
 results/pairs/wts/find_14/rowsum_0_2_6_4/pair_ZW.pair
-Sorting the files took 9 seconds. 
+Sorting the files took 5 seconds. 
  
 
 ./results/pairs/wts/find_14
 Folder rowsum_0_2_4_6 : sequences have order (W, Z, Y, X)
-Folder rowsum_0_2_6_4 : sequences have order (Z, W, Y, X)
-
-count before equivalences 6716
-The function found a total of 612864 sequences without any equivalences
-count after equivalences 96
-Matching the sequences took 68 seconds. 
+thread 'main' panicked at src/find/find_write.rs:469:40:
+index out of bounds: the len is 2002 but the index is 2816
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 267 seconds.
+Total execution time was 135 seconds.

--- a/rust/results/pairs/wts/find_15/result.log
+++ b/rust/results/pairs/wts/find_15/result.log
@@ -4,22 +4,22 @@
 (-1, 3, 5, 5)
 generated 4 different rowsums
 results/pairs/wts/find_15/rowsum_1_1_3_7
-The function took: 0.13851541 seconds to generate sequences with rowsums: 7, 3, 1, 1
-The function took: 393.80432 seconds to go through the two sets of pairs
+The function took: 0.13813339 seconds to generate sequences with rowsums: 7, 3, 1, 1
+The function took: 282.12137 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_15/rowsum_-1_1_3_7
-The function took: 0.14637329 seconds to generate sequences with rowsums: 7, 3, 1, -1
-The function took: 395.3328 seconds to go through the two sets of pairs
+The function took: 0.028339012 seconds to generate sequences with rowsums: 7, 3, 1, -1
+The function took: 279.81027 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_15/rowsum_1_3_5_5
-The function took: 0.12905575 seconds to generate sequences with rowsums: 5, 5, 3, 1
-The function took: 346.20316 seconds to go through the two sets of pairs
+The function took: 0.05907692 seconds to generate sequences with rowsums: 5, 5, 3, 1
+The function took: 247.18962 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_15/rowsum_-1_3_5_5
-The function took: 0.1203444 seconds to generate sequences with rowsums: 5, 5, 3, -1
-The function took: 347.1504 seconds to go through the two sets of pairs
+The function took: 0.029786913 seconds to generate sequences with rowsums: 5, 5, 3, -1
+The function took: 252.60123 seconds to go through the two sets of pairs
 
-Creating the sequences took 1483 seconds. 
+Creating the sequences took 1063 seconds. 
  
 
 results/pairs/wts/find_15/rowsum_-1_1_3_7/pair_WZ.pair
@@ -30,19 +30,15 @@ results/pairs/wts/find_15/rowsum_1_1_3_7/pair_WZ.pair
 results/pairs/wts/find_15/rowsum_1_1_3_7/pair_YX.pair
 results/pairs/wts/find_15/rowsum_1_3_5_5/pair_YX.pair
 results/pairs/wts/find_15/rowsum_1_3_5_5/pair_ZW.pair
-Sorting the files took 120 seconds. 
+Sorting the files took 79 seconds. 
  
 
 ./results/pairs/wts/find_15
-Folder rowsum_1_3_5_5 : sequences have order (Z, W, Y, X)
-Folder rowsum_-1_1_3_7 : sequences have order (Y, X, W, Z)
-Folder rowsum_-1_3_5_5 : sequences have order (Y, X, Z, W)
-Folder rowsum_1_1_3_7 : sequences have order (W, Z, Y, X)
-
-count before equivalences 788
-The function found a total of 69120 sequences without any equivalences
-count after equivalences 14
-Matching the sequences took 58 seconds. 
+Folder rowsum_-1_1_3_7 : sequences have order (W, Z, Y, X)
+thread 'main' panicked at src/find/find_write.rs:469:40:
+index out of bounds: the len is 5005 but the index is 5027
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 1662 seconds.
+Total execution time was 1142 seconds.

--- a/rust/results/pairs/wts/find_16/result.log
+++ b/rust/results/pairs/wts/find_16/result.log
@@ -3,18 +3,18 @@
 (-4, 4, 4, 4)
 generated 3 different rowsums
 results/pairs/wts/find_16/rowsum_0_0_0_8
-The function took: 0.25618663 seconds to generate sequences with rowsums: 8, 0, 0, 0
-The function took: 1462.027 seconds to go through the two sets of pairs
+The function took: 0.05841695 seconds to generate sequences with rowsums: 8, 0, 0, 0
+The function took: 1198.5575 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_16/rowsum_4_4_4_4
-The function took: 0.102719516 seconds to generate sequences with rowsums: 4, 4, 4, 4
-The function took: 1071.0447 seconds to go through the two sets of pairs
+The function took: 0.07772233 seconds to generate sequences with rowsums: 4, 4, 4, 4
+The function took: 900.88666 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_16/rowsum_-4_4_4_4
-The function took: 0.114557825 seconds to generate sequences with rowsums: 4, 4, 4, -4
-The function took: 1074.1385 seconds to go through the two sets of pairs
+The function took: 0.16500589 seconds to generate sequences with rowsums: 4, 4, 4, -4
+The function took: 890.3454 seconds to go through the two sets of pairs
 
-Creating the sequences took 3607 seconds. 
+Creating the sequences took 2990 seconds. 
  
 
 results/pairs/wts/find_16/rowsum_-4_4_4_4/pair_WX.pair
@@ -23,18 +23,17 @@ results/pairs/wts/find_16/rowsum_0_0_0_8/pair_WY.pair
 results/pairs/wts/find_16/rowsum_0_0_0_8/pair_ZX.pair
 results/pairs/wts/find_16/rowsum_4_4_4_4/pair_XY.pair
 results/pairs/wts/find_16/rowsum_4_4_4_4/pair_ZW.pair
-Sorting the files took 253 seconds. 
+./sortpairs.sh: line 18: 3621193 Killed                  sort -S 1G -T $SLURM_TMPDIR $filename > $filename.sorted
+Sorting the files took 200 seconds. 
  
 
 ./results/pairs/wts/find_16
-Folder rowsum_0_0_0_8 : sequences have order (Z, X, W, Y)
-Folder rowsum_4_4_4_4 : sequences have order (X, Y, Z, W)
-Folder rowsum_-4_4_4_4 : sequences have order (Y, Z, W, X)
-
-count before equivalences 228256
-The function found a total of 1867776 sequences without any equivalences
-count after equivalences 216
-Matching the sequences took 418 seconds. 
+Folder rowsum_0_0_0_8 : sequences have order (W, Y, Z, X)
+Folder rowsum_4_4_4_4 : sequences have order (Z, W, X, Y)
+thread 'main' panicked at src/find/find_write.rs:435:44:
+Expected something after ':' !
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 106 seconds. 
  
 
-Total execution time was 4278 seconds.
+Total execution time was 3297 seconds.

--- a/rust/results/pairs/wts/find_17/result.log
+++ b/rust/results/pairs/wts/find_17/result.log
@@ -4,22 +4,22 @@
 (-3, 3, 5, 5)
 generated 4 different rowsums
 results/pairs/wts/find_17/rowsum_1_3_3_7
-The function took: 3.7808871 seconds to generate sequences with rowsums: 7, 3, 3, 1
-The function took: 13776.602 seconds to go through the two sets of pairs
+The function took: 0.10722791 seconds to generate sequences with rowsums: 7, 3, 3, 1
+The function took: 9101.387 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_17/rowsum_-1_3_3_7
-The function took: 0.44996035 seconds to generate sequences with rowsums: 7, 3, 3, -1
-The function took: 13744.864 seconds to go through the two sets of pairs
+The function took: 0.099559985 seconds to generate sequences with rowsums: 7, 3, 3, -1
+The function took: 9102.783 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_17/rowsum_3_3_5_5
-The function took: 0.19012836 seconds to generate sequences with rowsums: 5, 5, 3, 3
-The function took: 12431.009 seconds to go through the two sets of pairs
+The function took: 0.08150197 seconds to generate sequences with rowsums: 5, 5, 3, 3
+The function took: 8506.369 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_17/rowsum_-3_3_5_5
-The function took: 0.1918596 seconds to generate sequences with rowsums: 5, 5, 3, -3
-The function took: 12420.715 seconds to go through the two sets of pairs
+The function took: 0.13721144 seconds to generate sequences with rowsums: 5, 5, 3, -3
+The function took: 8558.617 seconds to go through the two sets of pairs
 
-Creating the sequences took 52379 seconds. 
+Creating the sequences took 35271 seconds. 
  
 
 results/pairs/wts/find_17/rowsum_-1_3_3_7/pair_WY.pair
@@ -30,19 +30,15 @@ results/pairs/wts/find_17/rowsum_1_3_3_7/pair_WY.pair
 results/pairs/wts/find_17/rowsum_1_3_3_7/pair_ZX.pair
 results/pairs/wts/find_17/rowsum_3_3_5_5/pair_XY.pair
 results/pairs/wts/find_17/rowsum_3_3_5_5/pair_ZW.pair
-Sorting the files took 1459 seconds. 
+Sorting the files took 1115 seconds. 
  
 
 ./results/pairs/wts/find_17
-Folder rowsum_1_3_3_7 : sequences have order (W, Y, Z, X)
 Folder rowsum_3_3_5_5 : sequences have order (X, Y, Z, W)
-Folder rowsum_-1_3_3_7 : sequences have order (W, Y, Z, X)
-Folder rowsum_-3_3_5_5 : sequences have order (Z, W, Y, X)
-
-count before equivalences 1494
-The function found a total of 104448 sequences without any equivalences
-count after equivalences 10
-Matching the sequences took 605 seconds. 
+thread 'main' panicked at src/find/find_write.rs:470:40:
+index out of bounds: the len is 12376 but the index is 15612
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 1 seconds. 
  
 
-Total execution time was 54445 seconds.
+Total execution time was 36387 seconds.

--- a/rust/results/pairs/wts/find_2/result.log
+++ b/rust/results/pairs/wts/find_2/result.log
@@ -1,24 +1,24 @@
 (0, 0, 2, 2)
 generated 1 different rowsums
 results/pairs/wts/find_2/rowsum_0_0_2_2
-The function took: 0.056249447 seconds to generate sequences with rowsums: 2, 2, 0, 0
-The function took: 0.017089952 seconds to go through the two sets of pairs
+The function took: 0.011846483 seconds to generate sequences with rowsums: 2, 2, 0, 0
+The function took: 0.018765585 seconds to go through the two sets of pairs
 
-Creating the sequences took 2 seconds. 
+Creating the sequences took 0 seconds. 
  
 
 results/pairs/wts/find_2/rowsum_0_0_2_2/pair_XY.pair
 results/pairs/wts/find_2/rowsum_0_0_2_2/pair_ZW.pair
-Sorting the files took 1 seconds. 
+Sorting the files took 0 seconds. 
  
 
 ./results/pairs/wts/find_2
-Folder rowsum_0_0_2_2 : sequences have order (Z, W, X, Y)
+Folder rowsum_0_0_2_2 : sequences have order (X, Y, Z, W)
 
 count before equivalences 4
-The function found a total of 96 sequences without any equivalences
-count after equivalences 2
+The function found a total of 48 sequences without any equivalences
+count after equivalences 1
 Matching the sequences took 0 seconds. 
  
 
-Total execution time was 3 seconds.
+Total execution time was 1 seconds.

--- a/rust/results/pairs/wts/find_3/result.log
+++ b/rust/results/pairs/wts/find_3/result.log
@@ -2,14 +2,14 @@
 (-1, 1, 1, 3)
 generated 2 different rowsums
 results/pairs/wts/find_3/rowsum_1_1_1_3
-The function took: 0.09754738 seconds to generate sequences with rowsums: 3, 1, 1, 1
-The function took: 0.05890136 seconds to go through the two sets of pairs
+The function took: 0.03313784 seconds to generate sequences with rowsums: 3, 1, 1, 1
+The function took: 0.01921571 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_3/rowsum_-1_1_1_3
-The function took: 0.1023891 seconds to generate sequences with rowsums: 3, 1, 1, -1
-The function took: 0.057498857 seconds to go through the two sets of pairs
+The function took: 0.032749526 seconds to generate sequences with rowsums: 3, 1, 1, -1
+The function took: 0.020184305 seconds to go through the two sets of pairs
 
-Creating the sequences took 3 seconds. 
+Creating the sequences took 1 seconds. 
  
 
 results/pairs/wts/find_3/rowsum_-1_1_1_3/pair_WY.pair
@@ -20,13 +20,13 @@ Sorting the files took 0 seconds.
  
 
 ./results/pairs/wts/find_3
-Folder rowsum_1_1_1_3 : sequences have order (W, Y, Z, X)
-Folder rowsum_-1_1_1_3 : sequences have order (W, Y, Z, X)
+Folder rowsum_1_1_1_3 : sequences have order (Z, X, W, Y)
+Folder rowsum_-1_1_1_3 : sequences have order (Z, X, W, Y)
 
-count before equivalences 10
+count before equivalences 6
 The function found a total of 192 sequences without any equivalences
 count after equivalences 2
 Matching the sequences took 0 seconds. 
  
 
-Total execution time was 4 seconds.
+Total execution time was 1 seconds.

--- a/rust/results/pairs/wts/find_4/result.log
+++ b/rust/results/pairs/wts/find_4/result.log
@@ -3,18 +3,18 @@
 (-2, 2, 2, 2)
 generated 3 different rowsums
 results/pairs/wts/find_4/rowsum_0_0_0_4
-The function took: 0.06947779 seconds to generate sequences with rowsums: 4, 0, 0, 0
-The function took: 0.025663063 seconds to go through the two sets of pairs
+The function took: 0.021584775 seconds to generate sequences with rowsums: 4, 0, 0, 0
+The function took: 0.021563005 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_4/rowsum_2_2_2_2
-The function took: 0.05215063 seconds to generate sequences with rowsums: 2, 2, 2, 2
-The function took: 0.03205906 seconds to go through the two sets of pairs
+The function took: 0.00751101 seconds to generate sequences with rowsums: 2, 2, 2, 2
+The function took: 0.002335486 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_4/rowsum_-2_2_2_2
-The function took: 0.0783127 seconds to generate sequences with rowsums: 2, 2, 2, -2
-The function took: 0.050552737 seconds to go through the two sets of pairs
+The function took: 0.07242721 seconds to generate sequences with rowsums: 2, 2, 2, -2
+The function took: 0.002468236 seconds to go through the two sets of pairs
 
-Creating the sequences took 1 seconds. 
+Creating the sequences took 0 seconds. 
  
 
 results/pairs/wts/find_4/rowsum_-2_2_2_2/pair_WX.pair
@@ -27,14 +27,14 @@ Sorting the files took 0 seconds.
  
 
 ./results/pairs/wts/find_4
+Folder rowsum_-2_2_2_2 : sequences have order (Y, Z, W, X)
 Folder rowsum_2_2_2_2 : sequences have order (Z, W, X, Y)
 Folder rowsum_0_0_0_4 : sequences have order (Z, X, W, Y)
-Folder rowsum_-2_2_2_2 : sequences have order (Y, Z, W, X)
 
-count before equivalences 115
-The function found a total of 896 sequences without any equivalences
-count after equivalences 7
-Matching the sequences took 1 seconds. 
+count before equivalences 101
+The function found a total of 768 sequences without any equivalences
+count after equivalences 6
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 2 seconds.
+Total execution time was 0 seconds.

--- a/rust/results/pairs/wts/find_5/result.log
+++ b/rust/results/pairs/wts/find_5/result.log
@@ -2,14 +2,14 @@
 (-1, 1, 3, 3)
 generated 2 different rowsums
 results/pairs/wts/find_5/rowsum_1_1_3_3
-The function took: 0.051499438 seconds to generate sequences with rowsums: 3, 3, 1, 1
-The function took: 0.031918645 seconds to go through the two sets of pairs
+The function took: 0.10984273 seconds to generate sequences with rowsums: 3, 3, 1, 1
+The function took: 0.033488695 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_5/rowsum_-1_1_3_3
-The function took: 0.0820065 seconds to generate sequences with rowsums: 3, 3, 1, -1
-The function took: 0.025686081 seconds to go through the two sets of pairs
+The function took: 0.061954018 seconds to generate sequences with rowsums: 3, 3, 1, -1
+The function took: 0.003164798 seconds to go through the two sets of pairs
 
-Creating the sequences took 1 seconds. 
+Creating the sequences took 0 seconds. 
  
 
 results/pairs/wts/find_5/rowsum_-1_1_3_3/pair_YX.pair
@@ -20,13 +20,11 @@ Sorting the files took 0 seconds.
  
 
 ./results/pairs/wts/find_5
-Folder rowsum_-1_1_3_3 : sequences have order (Z, W, Y, X)
-Folder rowsum_1_1_3_3 : sequences have order (X, Y, Z, W)
-
-count before equivalences 22
-The function found a total of 960 sequences without any equivalences
-count after equivalences 2
-Matching the sequences took 1 seconds. 
+Folder rowsum_1_1_3_3 : sequences have order (Z, W, X, Y)
+thread 'main' panicked at src/find/find_write.rs:470:40:
+index out of bounds: the len is 5 but the index is 7
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 2 seconds.
+Total execution time was 0 seconds.

--- a/rust/results/pairs/wts/find_6/result.log
+++ b/rust/results/pairs/wts/find_6/result.log
@@ -1,10 +1,10 @@
 (0, 2, 2, 4)
 generated 1 different rowsums
 results/pairs/wts/find_6/rowsum_0_2_2_4
-The function took: 0.09334289 seconds to generate sequences with rowsums: 4, 2, 2, 0
-The function took: 0.062252197 seconds to go through the two sets of pairs
+The function took: 0.009316359 seconds to generate sequences with rowsums: 4, 2, 2, 0
+The function took: 0.020872092 seconds to go through the two sets of pairs
 
-Creating the sequences took 1 seconds. 
+Creating the sequences took 0 seconds. 
  
 
 results/pairs/wts/find_6/rowsum_0_2_2_4/pair_WY.pair
@@ -13,12 +13,11 @@ Sorting the files took 0 seconds.
  
 
 ./results/pairs/wts/find_6
-Folder rowsum_0_2_2_4 : sequences have order (W, Y, Z, X)
-
-count before equivalences 55
-The function found a total of 4608 sequences without any equivalences
-count after equivalences 8
-Matching the sequences took 1 seconds. 
+Folder rowsum_0_2_2_4 : sequences have order (Z, X, W, Y)
+thread 'main' panicked at src/find/find_write.rs:468:40:
+index out of bounds: the len is 15 but the index is 18
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 2 seconds.
+Total execution time was 0 seconds.

--- a/rust/results/pairs/wts/find_7/result.log
+++ b/rust/results/pairs/wts/find_7/result.log
@@ -4,22 +4,22 @@
 (-1, 3, 3, 3)
 generated 4 different rowsums
 results/pairs/wts/find_7/rowsum_1_1_1_5
-The function took: 0.19335914 seconds to generate sequences with rowsums: 5, 1, 1, 1
-The function took: 0.04389077 seconds to go through the two sets of pairs
+The function took: 0.022705575 seconds to generate sequences with rowsums: 5, 1, 1, 1
+The function took: 0.023657236 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_7/rowsum_-1_1_1_5
-The function took: 0.120045066 seconds to generate sequences with rowsums: 5, 1, 1, -1
-The function took: 0.057077408 seconds to go through the two sets of pairs
+The function took: 0.039214283 seconds to generate sequences with rowsums: 5, 1, 1, -1
+The function took: 0.028215408 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_7/rowsum_1_3_3_3
-The function took: 0.05948916 seconds to generate sequences with rowsums: 3, 3, 3, 1
-The function took: 0.053972907 seconds to go through the two sets of pairs
+The function took: 0.083300255 seconds to generate sequences with rowsums: 3, 3, 3, 1
+The function took: 0.016872471 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_7/rowsum_-1_3_3_3
-The function took: 0.045370527 seconds to generate sequences with rowsums: 3, 3, 3, -1
-The function took: 0.041817468 seconds to go through the two sets of pairs
+The function took: 0.045526154 seconds to generate sequences with rowsums: 3, 3, 3, -1
+The function took: 0.024808614 seconds to go through the two sets of pairs
 
-Creating the sequences took 1 seconds. 
+Creating the sequences took 0 seconds. 
  
 
 results/pairs/wts/find_7/rowsum_-1_1_1_5/pair_WY.pair
@@ -30,19 +30,15 @@ results/pairs/wts/find_7/rowsum_1_1_1_5/pair_WY.pair
 results/pairs/wts/find_7/rowsum_1_1_1_5/pair_ZX.pair
 results/pairs/wts/find_7/rowsum_1_3_3_3/pair_WX.pair
 results/pairs/wts/find_7/rowsum_1_3_3_3/pair_YZ.pair
-Sorting the files took 1 seconds. 
+Sorting the files took 0 seconds. 
  
 
 ./results/pairs/wts/find_7
-Folder rowsum_1_3_3_3 : sequences have order (Y, Z, W, X)
 Folder rowsum_-1_3_3_3 : sequences have order (W, X, Y, Z)
-Folder rowsum_1_1_1_5 : sequences have order (W, Y, Z, X)
-Folder rowsum_-1_1_1_5 : sequences have order (W, Y, Z, X)
-
-count before equivalences 254
-The function found a total of 6720 sequences without any equivalences
-count after equivalences 6
-Matching the sequences took 1 seconds. 
+thread 'main' panicked at src/find/find_write.rs:469:40:
+index out of bounds: the len is 21 but the index is 30
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 3 seconds.
+Total execution time was 0 seconds.

--- a/rust/results/pairs/wts/find_8/result.log
+++ b/rust/results/pairs/wts/find_8/result.log
@@ -1,10 +1,10 @@
 (0, 0, 4, 4)
 generated 1 different rowsums
 results/pairs/wts/find_8/rowsum_0_0_4_4
-The function took: 0.11271795 seconds to generate sequences with rowsums: 4, 4, 0, 0
-The function took: 1.7210186 seconds to go through the two sets of pairs
+The function took: 0.009281573 seconds to generate sequences with rowsums: 4, 4, 0, 0
+The function took: 0.047080792 seconds to go through the two sets of pairs
 
-Creating the sequences took 2 seconds. 
+Creating the sequences took 0 seconds. 
  
 
 results/pairs/wts/find_8/rowsum_0_0_4_4/pair_XY.pair
@@ -14,11 +14,10 @@ Sorting the files took 0 seconds.
 
 ./results/pairs/wts/find_8
 Folder rowsum_0_0_4_4 : sequences have order (Z, W, X, Y)
-
-count before equivalences 553
-The function found a total of 12288 sequences without any equivalences
-count after equivalences 14
-Matching the sequences took 1 seconds. 
+thread 'main' panicked at src/find/find_write.rs:470:40:
+index out of bounds: the len is 28 but the index is 50
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 4 seconds.
+Total execution time was 0 seconds.

--- a/rust/results/pairs/wts/find_9/result.log
+++ b/rust/results/pairs/wts/find_9/result.log
@@ -4,22 +4,22 @@
 (-3, 3, 3, 3)
 generated 4 different rowsums
 results/pairs/wts/find_9/rowsum_1_1_3_5
-The function took: 0.059250437 seconds to generate sequences with rowsums: 5, 3, 1, 1
-The function took: 0.22881809 seconds to go through the two sets of pairs
+The function took: 0.034430668 seconds to generate sequences with rowsums: 5, 3, 1, 1
+The function took: 0.0944492 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_9/rowsum_-1_1_3_5
-The function took: 0.09460099 seconds to generate sequences with rowsums: 5, 3, 1, -1
-The function took: 0.16591585 seconds to go through the two sets of pairs
+The function took: 0.005954811 seconds to generate sequences with rowsums: 5, 3, 1, -1
+The function took: 0.11621694 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_9/rowsum_3_3_3_3
-The function took: 0.016983323 seconds to generate sequences with rowsums: 3, 3, 3, 3
-The function took: 1.5204637 seconds to go through the two sets of pairs
+The function took: 0.23422651 seconds to generate sequences with rowsums: 3, 3, 3, 3
+The function took: 0.09210839 seconds to go through the two sets of pairs
 
 results/pairs/wts/find_9/rowsum_-3_3_3_3
-The function took: 0.0625466 seconds to generate sequences with rowsums: 3, 3, 3, -3
-The function took: 0.14816286 seconds to go through the two sets of pairs
+The function took: 0.039393794 seconds to generate sequences with rowsums: 3, 3, 3, -3
+The function took: 0.12153936 seconds to go through the two sets of pairs
 
-Creating the sequences took 3 seconds. 
+Creating the sequences took 1 seconds. 
  
 
 results/pairs/wts/find_9/rowsum_-1_1_3_5/pair_WZ.pair
@@ -30,19 +30,16 @@ results/pairs/wts/find_9/rowsum_1_1_3_5/pair_WZ.pair
 results/pairs/wts/find_9/rowsum_1_1_3_5/pair_YX.pair
 results/pairs/wts/find_9/rowsum_3_3_3_3/pair_XY.pair
 results/pairs/wts/find_9/rowsum_3_3_3_3/pair_ZW.pair
-Sorting the files took 1 seconds. 
+Sorting the files took 0 seconds. 
  
 
 ./results/pairs/wts/find_9
 Folder rowsum_-3_3_3_3 : sequences have order (Y, Z, W, X)
-Folder rowsum_3_3_3_3 : sequences have order (X, Y, Z, W)
-Folder rowsum_-1_1_3_5 : sequences have order (Y, X, W, Z)
-Folder rowsum_1_1_3_5 : sequences have order (Y, X, W, Z)
-
-count before equivalences 1582
-The function found a total of 25920 sequences without any equivalences
-count after equivalences 14
-Matching the sequences took 4 seconds. 
+Folder rowsum_1_1_3_5 : sequences have order (W, Z, Y, X)
+thread 'main' panicked at src/find/find_write.rs:469:40:
+index out of bounds: the len is 84 but the index is 95
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Matching the sequences took 0 seconds. 
  
 
-Total execution time was 8 seconds.
+Total execution time was 1 seconds.

--- a/rust/src/find/find_write.rs
+++ b/rust/src/find/find_write.rs
@@ -196,8 +196,8 @@ pub fn write_pairs_rowsum(folder : String, rs : (isize, isize, isize, isize), p 
 
     let now = Instant::now();
 
-    write_seq_pairs((&sequences_0, &sequences_1), (&tags[0], &tags[1]), p, &folder_path, EquationSide::LEFT);
-    write_seq_pairs((&sequences_2, &sequences_3), (&tags[2], &tags[3]), p, &folder_path, EquationSide::RIGHT);
+    write_seq_pairs((&sequences_0, &sequences_3), (&tags[0], &tags[1]), p, &folder_path, EquationSide::LEFT);
+    write_seq_pairs((&sequences_1, &sequences_2), (&tags[2], &tags[3]), p, &folder_path, EquationSide::RIGHT);
     
     let elapsed_time = now.elapsed().as_secs_f32();
     eprintln!("The function took: {elapsed_time} seconds to go through the two sets of pairs\n");


### PR DESCRIPTION
Switching from pairing $w$ with $x$ and $y$ with $z$ to pairing $w$ with $z$ and $x$ with $y$ provided more a more balanced number of sequences in each pair, reducing the runtime by around 33% for length 17. 